### PR TITLE
Mark `simd_shuffle` intrinsics as `rustc_args_required_const`

### DIFF
--- a/src/codegen/llvm.rs
+++ b/src/codegen/llvm.rs
@@ -10,31 +10,37 @@ extern "platform-intrinsic" {
     // FIXME: Passing this intrinsics an `idx` array with an index that is
     // out-of-bounds will produce a monomorphization-time error.
     // https://github.com/rust-lang-nursery/packed_simd/issues/21
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U
     where
         T: Simd,
         <T as Simd>::Element: Shuffle<[u32; 2], Output = U>;
 
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U
     where
         T: Simd,
         <T as Simd>::Element: Shuffle<[u32; 4], Output = U>;
 
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U
     where
         T: Simd,
         <T as Simd>::Element: Shuffle<[u32; 8], Output = U>;
 
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U
     where
         T: Simd,
         <T as Simd>::Element: Shuffle<[u32; 16], Output = U>;
 
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle32<T, U>(x: T, y: T, idx: [u32; 32]) -> U
     where
         T: Simd,
         <T as Simd>::Element: Shuffle<[u32; 32], Output = U>;
 
+    #[rustc_args_required_const(2)]
     pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U
     where
         T: Simd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@
 
 #![feature(
     repr_simd,
+    rustc_attrs,
     const_fn,
     platform_intrinsics,
     stdsimd,


### PR DESCRIPTION
This change was made in `stdarch` but not `packed_simd`. See rust-lang/rust#69280 for background.