### PR TITLE
Add non-pi version of `sin_cos` and add `acos`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -202,6 +202,7 @@ macro_rules! impl_f {
 
         // floating-point math
         impl_math_float_abs!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        impl_math_float_acos!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_cos!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_exp!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_ln!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
@@ -211,6 +212,7 @@ macro_rules! impl_f {
         impl_math_float_recpre!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_rsqrte!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_sin!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        impl_math_float_sin_cos!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_sqrt!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_sqrte!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_math_float_tanh!([$elem_ty; $elem_n]: $tuple_id | $test_tt);

--- a/src/api/math/float.rs
+++ b/src/api/math/float.rs
@@ -4,6 +4,9 @@
 mod abs;
 
 #[macro_use]
+mod acos;
+
+#[macro_use]
 mod consts;
 
 #[macro_use]
@@ -32,6 +35,9 @@ mod rsqrte;
 
 #[macro_use]
 mod sin;
+
+#[macro_use]
+mod sin_cos;
 
 #[macro_use]
 mod sqrt;

--- a/src/api/math/float/acos.rs
+++ b/src/api/math/float/acos.rs
@@ -1,0 +1,30 @@
+//! Implements vertical (lane-wise) floating-point `acos`.
+
+macro_rules! impl_math_float_acos {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
+        impl $id {
+            /// Arccosine.
+            #[inline]
+            pub fn acos(self) -> Self {
+                use crate::codegen::math::float::acos::Acos;
+                Acos::acos(self)
+            }
+        }
+
+        test_if!{
+            $test_tt:
+            paste::item! {
+                pub mod [<$id _math_acos>] {
+                    use super::*;
+                    #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+                    fn acos() {
+                        let z = $id::splat(0 as $elem_ty);
+                        let o = $id::splat(1 as $elem_ty);
+
+                        assert_eq!(z, o.acos());
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/api/math/float/sin.rs
+++ b/src/api/math/float/sin.rs
@@ -16,13 +16,6 @@ macro_rules! impl_math_float_sin {
                 use crate::codegen::math::float::sin_pi::SinPi;
                 SinPi::sin_pi(self)
             }
-
-            /// Sine and cosine of `self * PI`.
-            #[inline]
-            pub fn sin_cos_pi(self) -> (Self, Self) {
-                use crate::codegen::math::float::sin_cos_pi::SinCosPi;
-                SinCosPi::sin_cos_pi(self)
-            }
         }
 
         test_if!{

--- a/src/api/math/float/sin_cos.rs
+++ b/src/api/math/float/sin_cos.rs
@@ -1,0 +1,51 @@
+//! Implements vertical (lane-wise) floating-point `sin_cos` (fused sine and
+//! cosine).
+
+macro_rules! impl_math_float_sin_cos {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
+        impl $id {
+            /// Sine and cosine of `self`
+            #[inline]
+            pub fn sin_cos(self) -> (Self, Self) {
+                use crate::codegen::math::float::sin_cos::SinCos;
+                SinCos::sin_cos(self)
+            }
+
+            /// Sine and cosine of `self * PI`.
+            #[inline]
+            pub fn sin_cos_pi(self) -> (Self, Self) {
+                use crate::codegen::math::float::sin_cos_pi::SinCosPi;
+                SinCosPi::sin_cos_pi(self)
+            }
+        }
+
+        test_if!{
+            $test_tt:
+            paste::item! {
+                pub mod [<$id _math_sin_cos>] {
+                    use super::*;
+                    #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+                    fn sin_cos() {
+                        use crate::$elem_ty::consts::PI;
+                        let z = $id::splat(0 as $elem_ty);
+                        let o = $id::splat(1 as $elem_ty);
+                        let p = $id::splat(PI as $elem_ty);
+                        let ph = $id::splat(PI as $elem_ty / 2.);
+                        let (o_r_s, o_r_c) = ($id::splat((PI as $elem_ty / 2.).sin()), $id::splat((PI as $elem_ty / 2.).cos()));
+                        let (z_r_s, z_r_c) = ($id::splat((PI as $elem_ty).sin()), $id::splat((PI as $elem_ty).cos()));
+
+                        let (z_s, z_c) = z.sin_cos();
+                        let (ph_s, ph_c) = ph.sin_cos();
+                        let (p_s, p_c) = p.sin_cos();
+                        assert_eq!(z, z_s); // sin(0) = 0
+                        assert_eq!(o, z_c); // cos(0) = 1
+                        assert_eq!(o_r_s, ph.sin());
+                        assert_eq!(o_r_c, ph.cos());
+                        assert_eq!(z_r_s, p.sin());
+                        assert_eq!(z_r_c, p.cos());
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/codegen/math/float.rs
+++ b/src/codegen/math/float.rs
@@ -4,6 +4,7 @@
 #[macro_use]
 crate mod macros;
 crate mod abs;
+crate mod acos;
 crate mod cos;
 crate mod cos_pi;
 crate mod exp;
@@ -12,6 +13,7 @@ crate mod mul_add;
 crate mod mul_adde;
 crate mod powf;
 crate mod sin;
+crate mod sin_cos;
 crate mod sin_cos_pi;
 crate mod sin_pi;
 crate mod sqrt;

--- a/src/codegen/math/float/acos.rs
+++ b/src/codegen/math/float/acos.rs
@@ -1,0 +1,117 @@
+//! Vertical floating-point `acos`
+#![allow(unused)]
+
+// FIXME 64-bit 1 elem vectors acos
+
+use crate::*;
+
+crate trait Acos {
+    fn acos(self) -> Self;
+}
+
+macro_rules! define_acos {
+    ($name:ident, $basetype:ty, $simdtype:ty, $lanes:expr, $trait:path) => {
+        fn $name(x: $simdtype) -> $simdtype {
+            use core::intrinsics::transmute;
+            let mut buf: [$basetype; $lanes] = unsafe { transmute(x) };
+            for elem in &mut buf {
+                *elem = <$basetype as $trait>::acos(*elem);
+            }
+            unsafe { transmute(buf) }
+        }
+    };
+
+    (f32 => $name:ident, $type:ty, $lanes:expr) => {
+        define_acos!($name, f32, $type, $lanes, libm::F32Ext);
+    };
+
+    (f64 => $name:ident, $type:ty, $lanes:expr) => {
+        define_acos!($name, f64, $type, $lanes, libm::F64Ext);
+    };
+}
+
+// llvm does not seem to expose the hyperbolic versions of trigonometric
+// functions; we thus call the classical rust versions on all of them (which
+// stem from cmath).
+define_acos!(f32 => acos_v2f32, f32x2, 2);
+define_acos!(f32 => acos_v4f32, f32x4, 4);
+define_acos!(f32 => acos_v8f32, f32x8, 8);
+define_acos!(f32 => acos_v16f32, f32x16, 16);
+
+define_acos!(f64 => acos_v2f64, f64x2, 2);
+define_acos!(f64 => acos_v4f64, f64x4, 4);
+define_acos!(f64 => acos_v8f64, f64x8, 8);
+
+fn acos_f32(x: f32) -> f32 {
+    libm::F32Ext::acos(x)
+}
+
+fn acos_f64(x: f64) -> f64 {
+    libm::F64Ext::acos(x)
+}
+
+gen_unary_impl_table!(Acos, acos);
+
+cfg_if! {
+    if #[cfg(target_arch = "s390x")] {
+        // FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/14
+        impl_unary!(f32x2[f32; 2]: acos_f32);
+        impl_unary!(f32x4[f32; 4]: acos_f32);
+        impl_unary!(f32x8[f32; 8]: acos_f32);
+        impl_unary!(f32x16[f32; 16]: acos_f32);
+
+        impl_unary!(f64x2[f64; 2]: acos_f64);
+        impl_unary!(f64x4[f64; 4]: acos_f64);
+        impl_unary!(f64x8[f64; 8]: acos_f64);
+    } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
+        use sleef_sys::*;
+        cfg_if! {
+            if #[cfg(target_feature = "avx2")] {
+                impl_unary!(f32x2[t => f32x4]: Sleef_acosf4_u10avx2128);
+                impl_unary!(f32x16[h => f32x8]: Sleef_acosf8_u10avx2);
+                impl_unary!(f64x8[h => f64x4]: Sleef_acosd4_u10avx2);
+
+                impl_unary!(f32x4: Sleef_acosf4_u10avx2128);
+                impl_unary!(f32x8: Sleef_acosf8_u10avx2);
+                impl_unary!(f64x2: Sleef_acosd2_u10avx2128);
+                impl_unary!(f64x4: Sleef_acosd4_u10avx2);
+            } else if #[cfg(target_feature = "avx")] {
+                impl_unary!(f32x2[t => f32x4]: Sleef_acosf4_u10sse4);
+                impl_unary!(f32x16[h => f32x8]: Sleef_acosf8_u10avx);
+                impl_unary!(f64x8[h => f64x4]: Sleef_acosd4_u10avx);
+
+                impl_unary!(f32x4: Sleef_acosf4_u10sse4);
+                impl_unary!(f32x8: Sleef_acosf8_u10avx);
+                impl_unary!(f64x2: Sleef_acosd2_u10sse4);
+                impl_unary!(f64x4: Sleef_acosd4_u10avx);
+            } else if #[cfg(target_feature = "sse4.2")] {
+                impl_unary!(f32x2[t => f32x4]: Sleef_acosf4_u10sse4);
+                impl_unary!(f32x16[q => f32x4]: Sleef_acosf4_u10sse4);
+                impl_unary!(f64x8[q => f64x2]: Sleef_acosd2_u10sse4);
+
+                impl_unary!(f32x4: Sleef_acosf4_u10sse4);
+                impl_unary!(f32x8[h => f32x4]: Sleef_acosf4_u10sse4);
+                impl_unary!(f64x2: Sleef_acosd2_u10sse4);
+                impl_unary!(f64x4[h => f64x2]: Sleef_acosd2_u10sse4);
+            } else {
+                impl_unary!(f32x2[f32; 2]: acos_f32);
+                impl_unary!(f32x16: acos_v16f32);
+                impl_unary!(f64x8: acos_v8f64);
+
+                impl_unary!(f32x4: acos_v4f32);
+                impl_unary!(f32x8: acos_v8f32);
+                impl_unary!(f64x2: acos_v2f64);
+                impl_unary!(f64x4: acos_v4f64);
+            }
+        }
+    } else {
+        impl_unary!(f32x2[f32; 2]: acos_f32);
+        impl_unary!(f32x4: acos_v4f32);
+        impl_unary!(f32x8: acos_v8f32);
+        impl_unary!(f32x16: acos_v16f32);
+
+        impl_unary!(f64x2: acos_v2f64);
+        impl_unary!(f64x4: acos_v4f64);
+        impl_unary!(f64x8: acos_v8f64);
+    }
+}

--- a/src/codegen/math/float/sin_cos.rs
+++ b/src/codegen/math/float/sin_cos.rs
@@ -1,0 +1,183 @@
+//! Vertical floating-point `sin_cos`
+#![allow(unused)]
+
+// FIXME 64-bit 1 elem vectors sin_cos
+
+use crate::*;
+
+crate trait SinCos: Sized {
+    type Output;
+    fn sin_cos(self) -> Self::Output;
+}
+
+macro_rules! impl_def {
+    ($vid:ident) => {
+        impl SinCos for $vid {
+            type Output = (Self, Self);
+            #[inline]
+            fn sin_cos(self) -> Self::Output {
+                (self.sin(), self.cos())
+            }
+        }
+    };
+}
+
+macro_rules! impl_unary_t {
+    ($vid:ident: $fun:ident) => {
+        impl SinCos for $vid {
+            type Output = (Self, Self);
+            fn sin_cos(self) -> Self::Output {
+                unsafe {
+                    use crate::mem::transmute;
+                    transmute($fun(transmute(self)))
+                }
+            }
+        }
+    };
+    ($vid:ident[t => $vid_t:ident]: $fun:ident) => {
+        impl SinCos for $vid {
+            type Output = (Self, Self);
+            fn sin_cos(self) -> Self::Output {
+                unsafe {
+                    use crate::mem::{transmute, uninitialized};
+
+                    union U {
+                        vec: [$vid; 2],
+                        twice: $vid_t,
+                    }
+
+                    let twice = U { vec: [self, uninitialized()] }.twice;
+                    let twice = transmute($fun(transmute(twice)));
+
+                    union R {
+                        twice: ($vid_t, $vid_t),
+                        vecs: ([$vid; 2], [$vid; 2]),
+                    }
+                    let r = R { twice }.vecs;
+                    (*r.0.get_unchecked(0), *r.0.get_unchecked(1))
+                }
+            }
+        }
+    };
+    ($vid:ident[h => $vid_h:ident]: $fun:ident) => {
+        impl SinCos for $vid {
+            type Output = (Self, Self);
+            fn sin_cos(self) -> Self::Output {
+                unsafe {
+                    use crate::mem::transmute;
+
+                    union U {
+                        vec: $vid,
+                        halves: [$vid_h; 2],
+                    }
+
+                    let halves = U { vec: self }.halves;
+
+                    let res_0: ($vid_h, $vid_h) =
+                        transmute($fun(transmute(*halves.get_unchecked(0))));
+                    let res_1: ($vid_h, $vid_h) =
+                        transmute($fun(transmute(*halves.get_unchecked(1))));
+
+                    union R {
+                        result: ($vid, $vid),
+                        halves: ([$vid_h; 2], [$vid_h; 2]),
+                    }
+                    R { halves: ([res_0.0, res_1.0], [res_0.1, res_1.1]) }
+                        .result
+                }
+            }
+        }
+    };
+    ($vid:ident[q => $vid_q:ident]: $fun:ident) => {
+        impl SinCos for $vid {
+            type Output = (Self, Self);
+            fn sin_cos(self) -> Self::Output {
+                unsafe {
+                    use crate::mem::transmute;
+
+                    union U {
+                        vec: $vid,
+                        quarters: [$vid_q; 4],
+                    }
+
+                    let quarters = U { vec: self }.quarters;
+
+                    let res_0: ($vid_q, $vid_q) =
+                        transmute($fun(transmute(*quarters.get_unchecked(0))));
+                    let res_1: ($vid_q, $vid_q) =
+                        transmute($fun(transmute(*quarters.get_unchecked(1))));
+                    let res_2: ($vid_q, $vid_q) =
+                        transmute($fun(transmute(*quarters.get_unchecked(2))));
+                    let res_3: ($vid_q, $vid_q) =
+                        transmute($fun(transmute(*quarters.get_unchecked(3))));
+
+                    union R {
+                        result: ($vid, $vid),
+                        quarters: ([$vid_q; 4], [$vid_q; 4]),
+                    }
+                    R {
+                        quarters: (
+                            [res_0.0, res_1.0, res_2.0, res_3.0],
+                            [res_0.1, res_1.1, res_2.1, res_3.1],
+                        ),
+                    }
+                    .result
+                }
+            }
+        }
+    };
+}
+
+cfg_if! {
+    if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
+        use sleef_sys::*;
+        cfg_if! {
+            if #[cfg(target_feature = "avx2")] {
+                impl_unary_t!(f32x2[t => f32x4]: Sleef_sincosf4_u05avx2128);
+                impl_unary_t!(f32x16[h => f32x8]: Sleef_sincosf8_u05avx2);
+                impl_unary_t!(f64x8[h => f64x4]: Sleef_sincosd4_u05avx2);
+
+                impl_unary_t!(f32x4: Sleef_sincosf4_u05avx2128);
+                impl_unary_t!(f32x8: Sleef_sincosf8_u05avx2);
+                impl_unary_t!(f64x2: Sleef_sincosd2_u05avx2128);
+                impl_unary_t!(f64x4: Sleef_sincosd4_u05avx2);
+            } else if #[cfg(target_feature = "avx")] {
+                impl_unary_t!(f32x2[t => f32x4]: Sleef_sincosf4_u05sse4);
+                impl_unary_t!(f32x16[h => f32x8]: Sleef_sincosf8_u05avx);
+                impl_unary_t!(f64x8[h => f64x4]: Sleef_sincosd4_u05avx);
+
+                impl_unary_t!(f32x4: Sleef_sincosf4_u05sse4);
+                impl_unary_t!(f32x8: Sleef_sincosf8_u05avx);
+                impl_unary_t!(f64x2: Sleef_sincosd2_u05sse4);
+                impl_unary_t!(f64x4: Sleef_sincosd4_u05avx);
+            } else if #[cfg(target_feature = "sse4.2")] {
+                impl_unary_t!(f32x2[t => f32x4]: Sleef_sincosf4_u05sse4);
+                impl_unary_t!(f32x16[q => f32x4]: Sleef_sincosf4_u05sse4);
+                impl_unary_t!(f64x8[q => f64x2]: Sleef_sincosd2_u05sse4);
+
+                impl_unary_t!(f32x4: Sleef_sincosf4_u05sse4);
+                impl_unary_t!(f32x8[h => f32x4]: Sleef_sincosf4_u05sse4);
+                impl_unary_t!(f64x2: Sleef_sincosd2_u05sse4);
+                impl_unary_t!(f64x4[h => f64x2]: Sleef_sincosd2_u05sse4);
+            } else {
+                impl_def!(f32x2);
+                impl_def!(f32x4);
+                impl_def!(f32x8);
+                impl_def!(f32x16);
+
+                impl_def!(f64x2);
+                impl_def!(f64x4);
+                impl_def!(f64x8);
+            }
+        }
+    } else {
+        impl_def!(f32x2);
+        impl_def!(f32x4);
+        impl_def!(f32x8);
+        impl_def!(f32x16);
+
+        impl_def!(f64x2);
+        impl_def!(f64x4);
+        impl_def!(f64x8);
+    }
+}


### PR DESCRIPTION
Adds one more function from #227 and provides a non-pi-multiplied version of `sin_cos()`. Needed for use in [`ultraviolet`](https://github.com/termhn/ultraviolet/commit/75106a7335882fb14c41bfe9ec18d38ac6fdd02c).