### PR TITLE
Replace `_mm_movemask_pi8` with the fallback_impl

### DIFF
--- a/src/codegen/reductions/mask/x86.rs
+++ b/src/codegen/reductions/mask/x86.rs
@@ -19,13 +19,7 @@ mod avx2;
 /// x86 64-bit m8x8 implementation
 macro_rules! x86_m8x8_impl {
     ($id:ident) => {
-        cfg_if! {
-            if #[cfg(all(target_arch = "x86_64", target_feature = "sse"))] {
-                x86_m8x8_sse_impl!($id);
-            } else {
-                fallback_impl!($id);
-            }
-        }
+        fallback_impl!($id);
     };
 }
 

--- a/src/codegen/reductions/mask/x86/sse.rs
+++ b/src/codegen/reductions/mask/x86/sse.rs
@@ -34,35 +34,3 @@ macro_rules! x86_m32x4_sse_impl {
         }
     };
 }
-
-macro_rules! x86_m8x8_sse_impl {
-    ($id:ident) => {
-        impl All for $id {
-            #[inline]
-            #[target_feature(enable = "sse")]
-            unsafe fn all(self) -> bool {
-                #[cfg(target_arch = "x86")]
-                use crate::arch::x86::_mm_movemask_pi8;
-                #[cfg(target_arch = "x86_64")]
-                use crate::arch::x86_64::_mm_movemask_pi8;
-                // _mm_movemask_pi8(a) creates an 8bit mask containing the most
-                // significant bit of each byte of `a`. If all bits are set,
-                // then all 8 lanes of the mask are true.
-                _mm_movemask_pi8(crate::mem::transmute(self))
-                    == u8::max_value() as i32
-            }
-        }
-        impl Any for $id {
-            #[inline]
-            #[target_feature(enable = "sse")]
-            unsafe fn any(self) -> bool {
-                #[cfg(target_arch = "x86")]
-                use crate::arch::x86::_mm_movemask_pi8;
-                #[cfg(target_arch = "x86_64")]
-                use crate::arch::x86_64::_mm_movemask_pi8;
-
-                _mm_movemask_pi8(crate::mem::transmute(self)) != 0
-            }
-        }
-    };
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,6 @@
     link_llvm_intrinsics,
     core_intrinsics,
     stmt_expr_attributes,
-    mmx_target_feature,
     crate_visibility_modifier,
     custom_inner_attributes
 )]


### PR DESCRIPTION
`_mm_movemask_pi8` got removed from stdarch and there is no real alternative (`_mm_movemask_epi8` that was suggested [here](https://github.com/rust-lang/packed_simd/issues/288#issuecomment-695360559) doesn't take a 64bit wide vector but a 128bit vector instead) .

Resolves #288