### PR TITLE
Rebuild CI stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,16 +48,8 @@ jobs:
     - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
       name: "i686-unknown-linux-gnu + AVX2"
       stage: 32bit-tier1
-    - env: TARGET=x86_64-unknown-linux-gnu
-      name: "x86_64-unknown-linux-gnu + SSE2"
-      install: rustup component add rustfmt-preview
-      stage: build-test-verify
     - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
       name: "x86_64-unknown-linux-gnu + SSE4.2"
-      install: rustup component add rustfmt-preview
-      stage: build-test-verify
-    - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx"
-      name: "x86_64-unknown-linux-gnu + AVX"
       install: rustup component add rustfmt-preview
       stage: build-test-verify
     - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
@@ -125,14 +117,6 @@ jobs:
       name: "wasm32-unknown-unknown"
       stage: 32bit-tier2
     # MacOSX:
-    # Travis-CI OSX build bots do not support AVX2:
-    - os: osx
-      env: TARGET=x86_64-apple-darwin
-      name: "x86_64-apple-darwin + SSE2"
-      install: true
-      script: ci/run.sh
-      osx_image: xcode10
-      stage: build-test-verify
     - os: osx
       env: TARGET=x86_64-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
       name: "x86_64-apple-darwin + SSE4.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ stages:
   - 32bit-tier1
   - 64bit-tier2
   - 32bit-tier2
-  - android-and-ios
 
 jobs:
   fast_finish: true
@@ -29,7 +28,7 @@ jobs:
       stage: build-test-verify
     - env: TARGET="thumbv7neon-linux-androideabi"
       name: "thumbv7neon-linux-androideabi"
-      stage: android-and-ios
+      stage: 32bit-tier2
     # Linux:
     - env: TARGET=i586-unknown-linux-gnu
       name: "i586-unknown-linux-gnu"
@@ -126,25 +125,7 @@ jobs:
       name: "wasm32-unknown-unknown"
       stage: 32bit-tier2
     # MacOSX:
-    - os: osx
-      env: TARGET=i686-apple-darwin
-      name: "i686-apple-darwin + SSE2"
-      script: ci/run.sh
-      osx_image: xcode10
-      stage: 32bit-tier1
-    - os: osx
-      env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
-      name: "i686-apple-darwin + SSE4.2"
-      script: ci/run.sh
-      osx_image: xcode10
-      stage: 32bit-tier1
-      # Travis-CI OSX build bots do not support AVX2:
-    - os: osx
-      env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+avx"
-      name: "i686-apple-darwin + AVX"
-      script: ci/run.sh
-      osx_image: xcode10
-      stage: 32bit-tier1
+    # Travis-CI OSX build bots do not support AVX2:
     - os: osx
       env: TARGET=x86_64-apple-darwin
       name: "x86_64-apple-darwin + SSE2"
@@ -179,23 +160,11 @@ jobs:
     #  script: ci/run.sh
     # iOS:
     - os: osx
-      env: TARGET=i386-apple-ios
-      name: "i386-apple-ios"
-      script: ci/run.sh
-      osx_image: xcode9.4
-      stage: android-and-ios
-    - os: osx
       env: TARGET=x86_64-apple-ios
       name: "x86_64-apple-ios + SSE2"
       script: ci/run.sh
       osx_image: xcode9.4
-      stage: android-and-ios
-    - os: osx
-      env: TARGET=armv7-apple-ios NORUN=1
-      name: "armv7-apple-ios [Build only]"
-      script: ci/run.sh
-      osx_image: xcode9.4
-      stage: android-and-ios
+      stage: 64bit-tier2
     - name: "aarch64-apple-ios + NEON"
       env: TARGET=aarch64-apple-ios RUSTFLAGS="-C target-feature=+neon"
       os: osx
@@ -246,13 +215,11 @@ jobs:
     #- env: TARGET=x86_64-sun-solaris NORUN=1
 
     # FIXME: TBD
-    - stage: android-and-ios
     - stage: 64bit-tier2
     - stage: 32bit-tier2
 
     # FIXME: iOS
     # https://github.com/rust-lang-nursery/packed_simd/issues/26
-    - env: TARGET=i386-apple-ios
     - env: TARGET=x86_64-apple-ios
 
     # FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/182

--- a/.travis.yml
+++ b/.travis.yml
@@ -247,6 +247,17 @@ jobs:
   allow_failures:
     # FIXME: ISPC cannot be found?
     - name: "Benchmarks - x86_64-apple-darwin"
+    # FIXME: tier 1 fails inlining? Really?
+    - env: TARGET=i686-unknown-linux-gnu
+    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse"
+    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
+    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx"
+    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
+    - env: TARGET=i686-apple-darwin
+    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+sse"
+    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
+    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+avx"
+    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+avx2"
     # FIXME: TBD
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ jobs:
   fast_finish: true
   include:
     # Android:
-    - env: TARGET=x86_64-linux-android NOVERIFY=1
+    - env: TARGET=x86_64-linux-android
       name: "x86_64-unknown-linux-android + SSE2"
-      stage: android-and-ios
+      stage: build-test-verify
     - env: TARGET=arm-linux-androideabi
       name: "arm-linux-androideabi"
-      stage: android-and-ios
+      stage: build-test-verify
     - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"
       name: "arm-linux-androideabi + NEON"
-      stage: android-and-ios
+      stage: build-test-verify
     - name: "aarch64-unknown-linux-android + NEON"
       env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
       stage: build-test-verify
@@ -196,12 +196,12 @@ jobs:
       script: ci/run.sh
       osx_image: xcode9.4
       stage: android-and-ios
-    - name: "aarch64-apple-ios [Build only]"
-      env: TARGET=aarch64-apple-ios RUSTFLAGS="-C target-feature=+neon" NORUN=1
+    - name: "aarch64-apple-ios + NEON"
+      env: TARGET=aarch64-apple-ios RUSTFLAGS="-C target-feature=+neon"
       os: osx
       osx_image: xcode9.4
       script: ci/run.sh
-      stage: android-and-ios
+      stage: 64bit-tier2
     # BENCHMARKS:
     - name: "Benchmarks - x86_64-unknown-linux-gnu"
       install: TARGET=x86_64-unknown-linux-gnu ./ci/setup_benchmarks.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -205,6 +205,8 @@ jobs:
     # FIXME: iOS
     # https://github.com/rust-lang-nursery/packed_simd/issues/26
     - env: TARGET=x86_64-apple-ios
+    # Is this related to the above? Mysterious test failure
+    - name: "aarch64-apple-ios + NEON"
 
     # FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/182
     - env: TARGET=arm-unknown-linux-gnueabi RUSTFLAGS="-C target-feature=+v7,+neon"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
-sudo: false
 rust: nightly
+os: linux
+dist: focal
 
 stages:
   - tools
@@ -10,7 +11,7 @@ stages:
   - linux-tier2
   - android
 
-matrix:
+jobs:
   fast_finish: true
   include:
     # Android:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,26 +67,6 @@ matrix:
       name: "x86_64-unknown-linux-gnu + AVX2"
       install: rustup component add rustfmt-preview
       stage: linux-tier1
-    - env: TARGET=x86_64-unknown-linux-gnu-emulated
-      name: "Intel SDE + SSE2"
-      install: true
-      stage: linux-tier1
-    - env: TARGET=x86_64-unknown-linux-gnu-emulated RUSTFLAGS="-C target-feature=+sse4.2"
-      name: "Intel SDE + SSE4.2"
-      install: true
-      stage: linux-tier1
-    - env: TARGET=x86_64-unknown-linux-gnu-emulated RUSTFLAGS="-C target-feature=+avx"
-      name: "Intel SDE + AVX"
-      install: true
-      stage: linux-tier1
-    - env: TARGET=x86_64-unknown-linux-gnu-emulated RUSTFLAGS="-C target-feature=+avx2"
-      name: "Intel SDE + AVX2"
-      install: true
-      stage: linux-tier1
-    - env: TARGET=x86_64-unknown-linux-gnu-emulated RUSTFLAGS="-C target-feature=+avx-512f"
-      name: "Intel SDE + AVX-512"
-      install: true
-      stage: linux-tier1
     - env: TARGET=arm-unknown-linux-gnueabi
       name: "arm-unknown-linux-gnueabi"
       stage: linux-tier2

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ jobs:
     - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"
       name: "arm-linux-androideabi + NEON"
       stage: android-and-ios
-    - env: TARGET=aarch64-linux-android
-      name: "aarch64-unknown-linux-android"
-      stage: build-test-verify
     - name: "aarch64-unknown-linux-android + NEON"
       env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
       stage: build-test-verify
@@ -86,9 +83,6 @@ jobs:
     - env: TARGET="thumbv7neon-unknown-linux-gnueabihf"
       name: "thumbv7neon-unknown-linux-gnueabihf"
       stage: 32bit-tier2
-    - name: "aarch64-unknown-linux-gnu"
-      env: TARGET=aarch64-unknown-linux-gnu
-      stage: build-test-verify
     - name: "aarch64-unknown-linux-gnu + NEON"
       env: TARGET=aarch64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+neon"
       stage: build-test-verify
@@ -203,7 +197,7 @@ jobs:
       osx_image: xcode9.4
       stage: android-and-ios
     - name: "aarch64-apple-ios [Build only]"
-      env: TARGET=aarch64-apple-ios NORUN=1
+      env: TARGET=aarch64-apple-ios RUSTFLAGS="-C target-feature=+neon" NORUN=1
       os: osx
       osx_image: xcode9.4
       script: ci/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ dist: focal
 
 stages:
   - tools
-  - linux-tier1
-  - osx-tier1
-  - osx-tier2
-  - linux-tier2
-  - android
+  - build-test-verify # Passes full test suite, permit no regressions (unless it's rustup :/)
+  - 32bit-tier1
+  - 64bit-tier2
+  - 32bit-tier2
+  - android-and-ios
 
 jobs:
   fast_finish: true
@@ -17,157 +17,154 @@ jobs:
     # Android:
     - env: TARGET=x86_64-linux-android NOVERIFY=1
       name: "x86_64-unknown-linux-android + SSE2"
-      stage: android
+      stage: android-and-ios
     - env: TARGET=arm-linux-androideabi
       name: "arm-linux-androideabi"
-      stage: android
+      stage: android-and-ios
     - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"
       name: "arm-linux-androideabi + NEON"
-      stage: android
+      stage: android-and-ios
     - env: TARGET=aarch64-linux-android
       name: "aarch64-unknown-linux-android"
-      stage: android
-    - env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
-      name: "aarch64-unknown-linux-android + NEON"
-      stage: android
+      stage: build-test-verify
+    - name: "aarch64-unknown-linux-android + NEON"
+      env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
+      stage: build-test-verify
     - env: TARGET="thumbv7neon-linux-androideabi"
       name: "thumbv7neon-linux-androideabi"
-      stage: android
+      stage: android-and-ios
     # Linux:
     - env: TARGET=i586-unknown-linux-gnu
       name: "i586-unknown-linux-gnu"
-      stage: linux-tier2
+      stage: 32bit-tier2
     - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse"
       name: "i586-unknown-linux-gnu + SSE"
-      stage: linux-tier2
+      stage: 32bit-tier2
     - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse2"
       name: "i586-unknown-linux-gnu + SSE2"
-      stage: linux-tier2
+      stage: 32bit-tier2
     - env: TARGET=i686-unknown-linux-gnu
       name: "i686-unknown-linux-gnu + SSE2"
-      stage: linux-tier1
+      stage: 32bit-tier1
     - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
       name: "i686-unknown-linux-gnu + SSE4.2"
-      stage: linux-tier1
+      stage: 32bit-tier1
     - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
       name: "i686-unknown-linux-gnu + AVX2"
-      stage: linux-tier1
+      stage: 32bit-tier1
     - env: TARGET=x86_64-unknown-linux-gnu
       name: "x86_64-unknown-linux-gnu + SSE2"
       install: rustup component add rustfmt-preview
-      stage: linux-tier1
+      stage: build-test-verify
     - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
       name: "x86_64-unknown-linux-gnu + SSE4.2"
       install: rustup component add rustfmt-preview
-      stage: linux-tier1
+      stage: build-test-verify
     - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx"
       name: "x86_64-unknown-linux-gnu + AVX"
       install: rustup component add rustfmt-preview
-      stage: linux-tier1
+      stage: build-test-verify
     - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
       name: "x86_64-unknown-linux-gnu + AVX2"
       install: rustup component add rustfmt-preview
-      stage: linux-tier1
-    - env: TARGET=arm-unknown-linux-gnueabi
-      name: "arm-unknown-linux-gnueabi"
-      stage: linux-tier2
+      stage: build-test-verify
     - env: TARGET=arm-unknown-linux-gnueabi RUSTFLAGS="-C target-feature=+v7,+neon"
       name: "arm-unknown-linux-gnueabi + NEON"
-      stage: linux-tier2
+      stage: build-test-verify
     - env: TARGET=arm-unknown-linux-gnueabihf
       name: "arm-unknown-linux-gnueabihf"
-      stage: linux-tier2
+      stage: build-test-verify
     - env: TARGET=arm-unknown-linux-gnueabihf RUSTFLAGS="-C target-feature=+v7,+neon"
       name: "arm-unknown-linux-gnueabihf + NEON"
-      stage: linux-tier2
+      stage: build-test-verify
     - env: TARGET=armv7-unknown-linux-gnueabihf
       name: "armv7-unknown-linux-gnueabihf"
-      stage: linux-tier2
+      stage: build-test-verify
     - env: TARGET=armv7-unknown-linux-gnueabihf RUSTFLAGS="-C target-feature=+neon"
       name: "armv7-unknown-linux-gnueabihf + NEON"
-      stage: linux-tier2
+      stage: build-test-verify
     - env: TARGET="thumbv7neon-unknown-linux-gnueabihf"
       name: "thumbv7neon-unknown-linux-gnueabihf"
-      stage: linux-tier2
-    - env: TARGET=aarch64-unknown-linux-gnu
-      name: "aarch64-unknown-linux-gnu"
-      stage: linux-tier2
-    - env: TARGET=aarch64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+neon"
-      name: "aarch64-unknown-linux-gnu + NEON"
-      stage: linux-tier2
+      stage: 32bit-tier2
+    - name: "aarch64-unknown-linux-gnu"
+      env: TARGET=aarch64-unknown-linux-gnu
+      stage: build-test-verify
+    - name: "aarch64-unknown-linux-gnu + NEON"
+      env: TARGET=aarch64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+neon"
+      stage: build-test-verify
     - env: TARGET=mips-unknown-linux-gnu
       name: "mips-unknown-linux-gnu"
-      stage: linux-tier2
+      stage: 32bit-tier2
     - env: TARGET=mipsel-unknown-linux-musl
       name: "mipsel-unknown-linux-musl"
-      stage: linux-tier2
+      stage: 32bit-tier2
     - env: TARGET=mips64-unknown-linux-gnuabi64
       name: "mips64-unknown-linux-gnuabi64"
-      stage: linux-tier2
+      stage: 64bit-tier2
     - env: TARGET=mips64el-unknown-linux-gnuabi64
       name: "mips64el-unknown-linux-gnuabi64"
-      stage: linux-tier2
+      stage: 64bit-tier2
       # FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/18
       # env: TARGET=mips64el-unknown-linux-gnuabi64 RUSTFLAGS="-C target-feature=+msa -C target-cpu=mips64r6"
     - env: TARGET=powerpc-unknown-linux-gnu
       name: "powerpc-unknown-linux-gnu"
-      stage: linux-tier2
+      stage: 32bit-tier2
     - env: TARGET=powerpc64-unknown-linux-gnu
       name: "powerpc64-unknown-linux-gnu"
-      stage: linux-tier2
-    - env: TARGET=powerpc64le-unknown-linux-gnu
-      name: "powerpc64le-unknown-linux-gnu"
-      stage: linux-tier2
-    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+altivec"
-      name: "powerpc64le-unknown-linux-gnu + ALTIVEC"
-      stage: linux-tier2
-    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+vsx"
-      name: "powerpc64le-unknown-linux-gnu + VSX"
-      stage: linux-tier2
-    - env: TARGET=s390x-unknown-linux-gnu
-      name: "s390x-unknown-linux-gnu"
-      stage: linux-tier2
+      stage: 64bit-tier2
+    - name: "powerpc64le-unknown-linux-gnu"
+      env: TARGET=powerpc64le-unknown-linux-gnu
+      stage: build-test-verify
+    - name: "powerpc64le-unknown-linux-gnu + ALTIVEC"
+      env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+altivec"
+      stage: build-test-verify
+    - name: "powerpc64le-unknown-linux-gnu + VSX"
+      env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+vsx"
+      stage: build-test-verify
+    - name: "s390x-unknown-linux-gnu"
+      env: TARGET=s390x-unknown-linux-gnu
+      stage: 64bit-tier2
     - env: TARGET=sparc64-unknown-linux-gnu
       name: "sparc64-unknown-linux-gnu"
-      stage: linux-tier2
+      stage: 64bit-tier2
     # WebAssembly:
     - env: TARGET=wasm32-unknown-unknown
       name: "wasm32-unknown-unknown"
-      stage: osx-tier1 # For now
+      stage: 32bit-tier2
     # MacOSX:
     - os: osx
       env: TARGET=i686-apple-darwin
       name: "i686-apple-darwin + SSE2"
       script: ci/run.sh
       osx_image: xcode10
-      stage: osx-tier1
+      stage: 32bit-tier1
     - os: osx
       env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
       name: "i686-apple-darwin + SSE4.2"
       script: ci/run.sh
       osx_image: xcode10
-      stage: osx-tier1
+      stage: 32bit-tier1
       # Travis-CI OSX build bots do not support AVX2:
     - os: osx
       env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+avx"
       name: "i686-apple-darwin + AVX"
       script: ci/run.sh
       osx_image: xcode10
-      stage: osx-tier1
+      stage: 32bit-tier1
     - os: osx
       env: TARGET=x86_64-apple-darwin
       name: "x86_64-apple-darwin + SSE2"
       install: true
       script: ci/run.sh
       osx_image: xcode10
-      stage: osx-tier1
+      stage: build-test-verify
     - os: osx
       env: TARGET=x86_64-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
       name: "x86_64-apple-darwin + SSE4.2"
       install: true
       script: ci/run.sh
       osx_image: xcode10
-      stage: osx-tier1
+      stage: build-test-verify
       # Travis-CI OSX build bots do not support AVX2:
     - os: osx
       env: TARGET=x86_64-apple-darwin RUSTFLAGS="-C target-feature=+avx"
@@ -175,7 +172,7 @@ jobs:
       install: true
       script: ci/run.sh
       osx_image: xcode10
-      stage: osx-tier1
+      stage: build-test-verify
     # *BSDs:
     #- env: TARGET=i686-unknown-freebsd NORUN=1
     #  script: ci/run.sh
@@ -192,25 +189,25 @@ jobs:
       name: "i386-apple-ios"
       script: ci/run.sh
       osx_image: xcode9.4
-      stage: osx-tier2
+      stage: android-and-ios
     - os: osx
       env: TARGET=x86_64-apple-ios
       name: "x86_64-apple-ios + SSE2"
       script: ci/run.sh
       osx_image: xcode9.4
-      stage: osx-tier2
+      stage: android-and-ios
     - os: osx
       env: TARGET=armv7-apple-ios NORUN=1
       name: "armv7-apple-ios [Build only]"
       script: ci/run.sh
       osx_image: xcode9.4
-      stage: osx-tier2
-    - os: osx
+      stage: android-and-ios
+    - name: "aarch64-apple-ios [Build only]"
       env: TARGET=aarch64-apple-ios NORUN=1
-      name: "aarch64-apple-ios [Build only]"
-      script: ci/run.sh
+      os: osx
       osx_image: xcode9.4
-      stage: osx-tier2
+      script: ci/run.sh
+      stage: android-and-ios
     # BENCHMARKS:
     - name: "Benchmarks - x86_64-unknown-linux-gnu"
       install: TARGET=x86_64-unknown-linux-gnu ./ci/setup_benchmarks.sh
@@ -247,33 +244,17 @@ jobs:
   allow_failures:
     # FIXME: ISPC cannot be found?
     - name: "Benchmarks - x86_64-apple-darwin"
-    # FIXME: tier 1 fails inlining? Really?
-    - env: TARGET=i686-unknown-linux-gnu
-    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse"
-    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
-    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx"
-    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
-    - env: TARGET=i686-apple-darwin
-    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+sse"
-    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
-    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+avx"
-    - env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+avx2"
-    # FIXME: TBD
-    - env: TARGET=powerpc-unknown-linux-gnu
-    - env: TARGET=powerpc64-unknown-linux-gnu
-    - env: TARGET=powerpc64le-unknown-linux-gnu
-    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+altivec"
-    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+vsx"
+    # FIXME: i686 fails in inlining, apparently
+    - stage: 32bit-tier1
     #- env: TARGET=i686-unknown-freebsd NORUN=1
     #- env: TARGET=x86_64-unknown-freebsd NORUN=1
     #- env: TARGET=x86_64-unknown-netbsd NORUN=1
     #- env: TARGET=x86_64-sun-solaris NORUN=1
 
     # FIXME: TBD
-    - env: TARGET=arm-linux-androideabi
-    - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"
-    - env: TARGET=aarch64-linux-android
-    - env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
+    - stage: android-and-ios
+    - stage: 64bit-tier2
+    - stage: 32bit-tier2
 
     # FIXME: iOS
     # https://github.com/rust-lang-nursery/packed_simd/issues/26

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,16 +214,19 @@
     llvm_asm
 )]
 #![allow(non_camel_case_types, non_snake_case,
-         clippy::cast_possible_truncation,
-         clippy::cast_lossless,
-         clippy::cast_possible_wrap,
-         clippy::cast_precision_loss,
-         // TODO: manually add the `#[must_use]` attribute where appropiate
-         clippy::must_use_candidate,
-         // This lint is currently broken for generic code
-         // See https://github.com/rust-lang/rust-clippy/issues/3410
-         clippy::use_self,
-         clippy::wrong_self_convention
+        // FIXME: these types are unsound in C FFI already
+        // See https://github.com/rust-lang/rust/issues/53346
+        improper_ctypes_definitions,
+        clippy::cast_possible_truncation,
+        clippy::cast_lossless,
+        clippy::cast_possible_wrap,
+        clippy::cast_precision_loss,
+        // TODO: manually add the `#[must_use]` attribute where appropriate
+        clippy::must_use_candidate,
+        // This lint is currently broken for generic code
+        // See https://github.com/rust-lang/rust-clippy/issues/3410
+        clippy::use_self,
+        clippy::wrong_self_convention,
 )]
 #![cfg_attr(test, feature(hashmap_internals))]
 #![deny(rust_2018_idioms, clippy::missing_inline_in_public_items)]

--- a/verify/verify/src/lib.rs
+++ b/verify/verify/src/lib.rs
@@ -1,3 +1,6 @@
+// FIXME: these types are unsound in C FFI already
+// See https://github.com/rust-lang/rust/issues/53346
+#![allow(improper_ctypes_definitions)]
 #![deny(warnings, rust_2018_idioms)]
 #![cfg_attr(test, feature(avx512_target_feature, abi_vectorcall, llvm_asm))]
 


### PR DESCRIPTION
Rebuilds CI into a set of stages that indicates first the "totally
supported" stage, marked "build-test-verify", then groups arches
by base pointer width and tier. This surfaces all targets which
currently have full expected functionality, so as to better identify
and limit future regressions.