### PR TITLE
Minor CI fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -213,11 +213,6 @@ jobs:
     # Is this related to the above? Mysterious test failure
     - name: "aarch64-apple-ios + NEON"
 
-    # FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/182
-    - env: TARGET=arm-unknown-linux-gnueabi RUSTFLAGS="-C target-feature=+v7,+neon"
-    - env: TARGET=arm-unknown-linux-gnueabihf RUSTFLAGS="-C target-feature=+v7,+neon"
-    - env: TARGET=armv7-unknown-linux-gnueabihf RUSTFLAGS="-C target-feature=+neon"
-
     # FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/183
     - env: TARGET=wasm32-unknown-unknown
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ jobs:
     - env: TARGET=arm-linux-androideabi
       name: "arm-linux-androideabi"
       stage: build-test-verify
-    - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"
-      name: "arm-linux-androideabi + NEON"
-      stage: build-test-verify
     - name: "aarch64-unknown-linux-android + NEON"
       env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
       stage: build-test-verify
@@ -56,14 +53,8 @@ jobs:
       name: "x86_64-unknown-linux-gnu + AVX2"
       install: rustup component add rustfmt-preview
       stage: build-test-verify
-    - env: TARGET=arm-unknown-linux-gnueabi RUSTFLAGS="-C target-feature=+v7,+neon"
-      name: "arm-unknown-linux-gnueabi + NEON"
-      stage: build-test-verify
     - env: TARGET=arm-unknown-linux-gnueabihf
       name: "arm-unknown-linux-gnueabihf"
-      stage: build-test-verify
-    - env: TARGET=arm-unknown-linux-gnueabihf RUSTFLAGS="-C target-feature=+v7,+neon"
-      name: "arm-unknown-linux-gnueabihf + NEON"
       stage: build-test-verify
     - env: TARGET=armv7-unknown-linux-gnueabihf
       name: "armv7-unknown-linux-gnueabihf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "packed_simd"
+name = "packed_simd_2"
 version = "0.3.4"
-authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>", "Jubilee Young <workingjubilee@gmail.com>"]
 description = "Portable Packed SIMD vectors"
 documentation = "https://docs.rs/crate/packed_simd/"
 homepage = "https://github.com/rust-lang-nursery/packed_simd"
@@ -13,11 +13,11 @@ build = "build.rs"
 edition = "2018"
 
 [badges]
-appveyor = { repository = "rust-lang-nursery/packed_simd" }
-travis-ci = { repository = "rust-lang-nursery/packed_simd" }
-codecov = { repository = "rust-lang-nursery/packed_simd" }
-is-it-maintained-issue-resolution = { repository = "rust-lang-nursery/packed_simd" }
-is-it-maintained-open-issues = { repository = "rust-lang-nursery/packed_simd" }
+appveyor = { repository = "rust-lang/packed_simd" }
+travis-ci = { repository = "rust-lang/packed_simd" }
+codecov = { repository = "rust-lang/packed_simd" }
+is-it-maintained-issue-resolution = { repository = "rust-lang/packed_simd" }
+is-it-maintained-open-issues = { repository = "rust-lang/packed_simd" }
 maintenance = { status = "experimental" }
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Implementation of [Rust RFC #2366: `std::simd`][rfc2366]
 
-[![Travis-CI Status]][travis] [![Appveyor Status]][appveyor] [![Latest Version]][crates.io] [![docs]][master_docs]
+[![Travis-CI Status]][travis] <!-- [![Appveyor Status]][appveyor] --> [![Latest Version]][crates.io] [![docs]][master_docs]
 
 **WARNING**: this crate only supports the most recent nightly Rust toolchain
 and will be superceded by [stdsimd](https://github.com/rust-lang/stdsimd).
@@ -129,8 +129,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in `packed_simd` by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[travis]: https://travis-ci.com/rust-lang-nursery/packed_simd
-[Travis-CI Status]: https://travis-ci.com/rust-lang-nursery/packed_simd.svg?branch=master
+[travis]: https://travis-ci.com/rust-lang/packed_simd
+[Travis-CI Status]: https://travis-ci.com/rust-lang/packed_simd.svg?branch=master
 [appveyor]: https://ci.appveyor.com/project/gnzlbg/packed-simd
 [Appveyor Status]: https://ci.appveyor.com/api/projects/status/hd7v9dvr442hgdix?svg=true
 [Latest Version]: https://img.shields.io/crates/v/packed_simd.svg


### PR DESCRIPTION
Uses the correct badge locations, obscures the AppVeyor badge (for now?), and requires ARM targets that aren't aarch64 to build.