### PR TITLE
README: Fix crate and docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ dual licensed as above, without any additional terms or conditions.
 [Travis-CI Status]: https://travis-ci.com/rust-lang/packed_simd.svg?branch=master
 [appveyor]: https://ci.appveyor.com/project/gnzlbg/packed-simd
 [Appveyor Status]: https://ci.appveyor.com/api/projects/status/hd7v9dvr442hgdix?svg=true
-[Latest Version]: https://img.shields.io/crates/v/packed_simd.svg
-[crates.io]: https://crates.io/crates/packed_simd
-[docs]: https://docs.rs/packed_simd/badge.svg
-[docs.rs]: https://docs.rs/packed_simd/
-[master_docs]: https://rust-lang-nursery.github.io/packed_simd/packed_simd/
+[Latest Version]: https://img.shields.io/crates/v/packed_simd_2.svg
+[crates.io]: https://crates.io/crates/packed_simd_2
+[docs]: https://docs.rs/packed_simd_2/badge.svg
+[docs.rs]: https://docs.rs/packed_simd_2
+[master_docs]: https://rust-lang-nursery.github.io/packed_simd/packed_simd_2/
 [perf_guide]: https://rust-lang-nursery.github.io/packed_simd/perf-guide/
 [rfc2366]: https://github.com/rust-lang/rfcs/pull/2366
 [ISPC]: https://ispc.github.io/


### PR DESCRIPTION
This follows the rename to `packed_simd_2`. The URL shown at the repo info should be changed to https://rust-lang.github.io/packed_simd/packed_simd_2/ too, but I don't have the permission to do it.