### PR TITLE
Remove unnecessary the `const_fn` feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,6 @@
 #![feature(
     repr_simd,
     rustc_attrs,
-    const_fn,
     platform_intrinsics,
     stdsimd,
     aarch64_target_feature,


### PR DESCRIPTION
Fixes #320, caused by rust-lang/rust#85109
This exists since https://github.com/rust-lang/packed_simd/commit/1596d1bf28f0e29363c6a98711f393af7625b9a6#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R2 but now it's unnecessary as all the use here should be stabilized now.