### PR TITLE
Remove libm dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ maintenance = { status = "experimental" }
 [dependencies]
 cfg-if = "1.0.0"
 core_arch = { version = "0.1.5", optional = true }
-libm = "0.1.4"
 
 [features]
 default = []


### PR DESCRIPTION
libm was used to implement tanh, but it is not needed anymore for newer llvm.

Close: #294