### PR TITLE
Indirectly update to libm 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 cfg-if = "1.0.0"
 core_arch = { version = "0.1.5", optional = true }
-libm = "0.1.4"
+num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
 
 [features]
 default = []

--- a/src/codegen/math/float/tanh.rs
+++ b/src/codegen/math/float/tanh.rs
@@ -3,6 +3,9 @@
 
 // FIXME 64-bit 1 elem vectors tanh
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 use crate::*;
 
 crate trait Tanh {
@@ -22,11 +25,11 @@ macro_rules! define_tanh {
     };
 
     (f32 => $name:ident, $type:ty, $lanes:expr) => {
-        define_tanh!($name, f32, $type, $lanes, libm::F32Ext);
+        define_tanh!($name, f32, $type, $lanes, Float);
     };
 
     (f64 => $name:ident, $type:ty, $lanes:expr) => {
-        define_tanh!($name, f64, $type, $lanes, libm::F64Ext);
+        define_tanh!($name, f64, $type, $lanes, Float);
     };
 }
 
@@ -43,11 +46,11 @@ define_tanh!(f64 => tanh_v4f64, f64x4, 4);
 define_tanh!(f64 => tanh_v8f64, f64x8, 8);
 
 fn tanh_f32(x: f32) -> f32 {
-    libm::F32Ext::tanh(x)
+    Float::tanh(x)
 }
 
 fn tanh_f64(x: f64) -> f64 {
-    libm::F64Ext::tanh(x)
+    Float::tanh(x)
 }
 
 gen_unary_impl_table!(Tanh, tanh);


### PR DESCRIPTION
Unfortunately, `libm 0.2` remove the `F32Ext` and `F64Ext` extension
traits, which makes it harder to choose the different methods. However,
this was already dealt with in rust-num/num-traits#144 for `Float`, so
we can piggy-back on that here, no longer using `libm` directly.

Close: #294