### PR TITLE
Remove reference to unused llvm_asm feature (no longer available on Rust nightly)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,6 @@
     stmt_expr_attributes,
     crate_visibility_modifier,
     custom_inner_attributes,
-    llvm_asm
 )]
 #![allow(non_camel_case_types, non_snake_case,
         // FIXME: these types are unsound in C FFI already

--- a/verify/verify/src/lib.rs
+++ b/verify/verify/src/lib.rs
@@ -2,7 +2,7 @@
 // See https://github.com/rust-lang/rust/issues/53346
 #![allow(improper_ctypes_definitions)]
 #![deny(rust_2018_idioms)]
-#![cfg_attr(test, feature(avx512_target_feature, abi_vectorcall, llvm_asm))]
+#![cfg_attr(test, feature(avx512_target_feature, abi_vectorcall))]
 
 #[cfg(test)]
 mod api;


### PR DESCRIPTION
Fixes #340.