### PR TITLE
Replace `crate` with `pub(crate)`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,7 +2,7 @@
 
 #[macro_use]
 mod bitmask;
-crate mod cast;
+pub(crate) mod cast;
 #[macro_use]
 mod cmp;
 #[macro_use]
@@ -37,7 +37,7 @@ mod swap_bytes;
 mod bit_manip;
 
 #[cfg(feature = "into_bits")]
-crate mod into_bits;
+pub(crate) mod into_bits;
 
 macro_rules! impl_i {
     ([$elem_ty:ident; $elem_n:expr]: $tuple_id:ident, $mask_ty:ident

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,19 +1,19 @@
 //! Code-generation utilities
 
-crate mod bit_manip;
-crate mod llvm;
-crate mod math;
-crate mod reductions;
-crate mod shuffle;
-crate mod shuffle1_dyn;
-crate mod swap_bytes;
+pub(crate) mod bit_manip;
+pub(crate) mod llvm;
+pub(crate) mod math;
+pub(crate) mod reductions;
+pub(crate) mod shuffle;
+pub(crate) mod shuffle1_dyn;
+pub(crate) mod swap_bytes;
 
 macro_rules! impl_simd_array {
     ([$elem_ty:ident; $elem_count:expr]:
      $tuple_id:ident | $($elem_tys:ident),*) => {
         #[derive(Copy, Clone)]
         #[repr(simd)]
-        pub struct $tuple_id($(crate $elem_tys),*);
+        pub struct $tuple_id($(pub(crate) $elem_tys),*);
         //^^^^^^^ leaked through SimdArray
 
         impl crate::sealed::Seal for [$elem_ty; $elem_count] {}
@@ -35,28 +35,28 @@ macro_rules! impl_simd_array {
     }
 }
 
-crate mod pointer_sized_int;
+pub(crate) mod pointer_sized_int;
 
-crate mod v16;
-crate use self::v16::*;
+pub(crate) mod v16;
+pub(crate) use self::v16::*;
 
-crate mod v32;
-crate use self::v32::*;
+pub(crate) mod v32;
+pub(crate) use self::v32::*;
 
-crate mod v64;
-crate use self::v64::*;
+pub(crate) mod v64;
+pub(crate) use self::v64::*;
 
-crate mod v128;
-crate use self::v128::*;
+pub(crate) mod v128;
+pub(crate) use self::v128::*;
 
-crate mod v256;
-crate use self::v256::*;
+pub(crate) mod v256;
+pub(crate) use self::v256::*;
 
-crate mod v512;
-crate use self::v512::*;
+pub(crate) mod v512;
+pub(crate) use self::v512::*;
 
-crate mod vSize;
-crate use self::vSize::*;
+pub(crate) mod vSize;
+pub(crate) use self::vSize::*;
 
-crate mod vPtr;
-crate use self::vPtr::*;
+pub(crate) mod vPtr;
+pub(crate) use self::vPtr::*;

--- a/src/codegen/bit_manip.rs
+++ b/src/codegen/bit_manip.rs
@@ -1,7 +1,7 @@
 //! LLVM bit manipulation intrinsics.
 #[rustfmt::skip]
 
-use crate::*;
+pub(crate) use crate::*;
 
 #[allow(improper_ctypes, dead_code)]
 extern "C" {
@@ -147,7 +147,7 @@ extern "C" {
     fn ctpop_u128x4(x: u128x4) -> u128x4;
 }
 
-crate trait BitManip {
+pub(crate) trait BitManip {
     fn ctpop(self) -> Self;
     fn ctlz(self) -> Self;
     fn cttz(self) -> Self;

--- a/src/codegen/llvm.rs
+++ b/src/codegen/llvm.rs
@@ -76,53 +76,53 @@ where
 }
 
 extern "platform-intrinsic" {
-    crate fn simd_eq<T, U>(x: T, y: T) -> U;
-    crate fn simd_ne<T, U>(x: T, y: T) -> U;
-    crate fn simd_lt<T, U>(x: T, y: T) -> U;
-    crate fn simd_le<T, U>(x: T, y: T) -> U;
-    crate fn simd_gt<T, U>(x: T, y: T) -> U;
-    crate fn simd_ge<T, U>(x: T, y: T) -> U;
+    pub(crate) fn simd_eq<T, U>(x: T, y: T) -> U;
+    pub(crate) fn simd_ne<T, U>(x: T, y: T) -> U;
+    pub(crate) fn simd_lt<T, U>(x: T, y: T) -> U;
+    pub(crate) fn simd_le<T, U>(x: T, y: T) -> U;
+    pub(crate) fn simd_gt<T, U>(x: T, y: T) -> U;
+    pub(crate) fn simd_ge<T, U>(x: T, y: T) -> U;
 
-    crate fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
-    crate fn simd_extract<T, U>(x: T, idx: u32) -> U;
+    pub(crate) fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
+    pub(crate) fn simd_extract<T, U>(x: T, idx: u32) -> U;
 
-    crate fn simd_cast<T, U>(x: T) -> U;
+    pub(crate) fn simd_cast<T, U>(x: T) -> U;
 
-    crate fn simd_add<T>(x: T, y: T) -> T;
-    crate fn simd_sub<T>(x: T, y: T) -> T;
-    crate fn simd_mul<T>(x: T, y: T) -> T;
-    crate fn simd_div<T>(x: T, y: T) -> T;
-    crate fn simd_rem<T>(x: T, y: T) -> T;
-    crate fn simd_shl<T>(x: T, y: T) -> T;
-    crate fn simd_shr<T>(x: T, y: T) -> T;
-    crate fn simd_and<T>(x: T, y: T) -> T;
-    crate fn simd_or<T>(x: T, y: T) -> T;
-    crate fn simd_xor<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_add<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_sub<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_mul<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_div<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_rem<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_shl<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_shr<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_and<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_or<T>(x: T, y: T) -> T;
+    pub(crate) fn simd_xor<T>(x: T, y: T) -> T;
 
-    crate fn simd_reduce_add_unordered<T, U>(x: T) -> U;
-    crate fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
-    crate fn simd_reduce_add_ordered<T, U>(x: T, acc: U) -> U;
-    crate fn simd_reduce_mul_ordered<T, U>(x: T, acc: U) -> U;
-    crate fn simd_reduce_min<T, U>(x: T) -> U;
-    crate fn simd_reduce_max<T, U>(x: T) -> U;
-    crate fn simd_reduce_min_nanless<T, U>(x: T) -> U;
-    crate fn simd_reduce_max_nanless<T, U>(x: T) -> U;
-    crate fn simd_reduce_and<T, U>(x: T) -> U;
-    crate fn simd_reduce_or<T, U>(x: T) -> U;
-    crate fn simd_reduce_xor<T, U>(x: T) -> U;
-    crate fn simd_reduce_all<T>(x: T) -> bool;
-    crate fn simd_reduce_any<T>(x: T) -> bool;
+    pub(crate) fn simd_reduce_add_unordered<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_add_ordered<T, U>(x: T, acc: U) -> U;
+    pub(crate) fn simd_reduce_mul_ordered<T, U>(x: T, acc: U) -> U;
+    pub(crate) fn simd_reduce_min<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_max<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_min_nanless<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_max_nanless<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_and<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_or<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_xor<T, U>(x: T) -> U;
+    pub(crate) fn simd_reduce_all<T>(x: T) -> bool;
+    pub(crate) fn simd_reduce_any<T>(x: T) -> bool;
 
-    crate fn simd_select<M, T>(m: M, a: T, b: T) -> T;
+    pub(crate) fn simd_select<M, T>(m: M, a: T, b: T) -> T;
 
-    crate fn simd_fmin<T>(a: T, b: T) -> T;
-    crate fn simd_fmax<T>(a: T, b: T) -> T;
+    pub(crate) fn simd_fmin<T>(a: T, b: T) -> T;
+    pub(crate) fn simd_fmax<T>(a: T, b: T) -> T;
 
-    crate fn simd_fsqrt<T>(a: T) -> T;
-    crate fn simd_fma<T>(a: T, b: T, c: T) -> T;
+    pub(crate) fn simd_fsqrt<T>(a: T) -> T;
+    pub(crate) fn simd_fma<T>(a: T, b: T, c: T) -> T;
 
-    crate fn simd_gather<T, P, M>(value: T, pointers: P, mask: M) -> T;
-    crate fn simd_scatter<T, P, M>(value: T, pointers: P, mask: M);
+    pub(crate) fn simd_gather<T, P, M>(value: T, pointers: P, mask: M) -> T;
+    pub(crate) fn simd_scatter<T, P, M>(value: T, pointers: P, mask: M);
 
-    crate fn simd_bitmask<T, U>(value: T) -> U;
+    pub(crate) fn simd_bitmask<T, U>(value: T) -> U;
 }

--- a/src/codegen/math.rs
+++ b/src/codegen/math.rs
@@ -1,3 +1,3 @@
 //! Vertical math operations
 
-crate mod float;
+pub(crate) mod float;

--- a/src/codegen/math/float.rs
+++ b/src/codegen/math/float.rs
@@ -2,18 +2,18 @@
 #![allow(clippy::useless_transmute)]
 
 #[macro_use]
-crate mod macros;
-crate mod abs;
-crate mod cos;
-crate mod cos_pi;
-crate mod exp;
-crate mod ln;
-crate mod mul_add;
-crate mod mul_adde;
-crate mod powf;
-crate mod sin;
-crate mod sin_cos_pi;
-crate mod sin_pi;
-crate mod sqrt;
-crate mod sqrte;
-crate mod tanh;
+pub(crate) mod macros;
+pub(crate) mod abs;
+pub(crate) mod cos;
+pub(crate) mod cos_pi;
+pub(crate) mod exp;
+pub(crate) mod ln;
+pub(crate) mod mul_add;
+pub(crate) mod mul_adde;
+pub(crate) mod powf;
+pub(crate) mod sin;
+pub(crate) mod sin_cos_pi;
+pub(crate) mod sin_pi;
+pub(crate) mod sqrt;
+pub(crate) mod sqrte;
+pub(crate) mod tanh;

--- a/src/codegen/math/float/abs.rs
+++ b/src/codegen/math/float/abs.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Abs {
+pub(crate) trait Abs {
     fn abs(self) -> Self;
 }
 

--- a/src/codegen/math/float/cos.rs
+++ b/src/codegen/math/float/cos.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Cos {
+pub(crate) trait Cos {
     fn cos(self) -> Self;
 }
 

--- a/src/codegen/math/float/cos_pi.rs
+++ b/src/codegen/math/float/cos_pi.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait CosPi {
+pub(crate) trait CosPi {
     fn cos_pi(self) -> Self;
 }
 

--- a/src/codegen/math/float/exp.rs
+++ b/src/codegen/math/float/exp.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Exp {
+pub(crate) trait Exp {
     fn exp(self) -> Self;
 }
 

--- a/src/codegen/math/float/ln.rs
+++ b/src/codegen/math/float/ln.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Ln {
+pub(crate) trait Ln {
     fn ln(self) -> Self;
 }
 

--- a/src/codegen/math/float/mul_add.rs
+++ b/src/codegen/math/float/mul_add.rs
@@ -4,7 +4,7 @@ use crate::*;
 
 // FIXME: 64-bit 1 element mul_add
 
-crate trait MulAdd {
+pub(crate) trait MulAdd {
     fn mul_add(self, y: Self, z: Self) -> Self;
 }
 

--- a/src/codegen/math/float/mul_adde.rs
+++ b/src/codegen/math/float/mul_adde.rs
@@ -3,7 +3,7 @@ use crate::*;
 
 // FIXME: 64-bit 1 element mul_adde
 
-crate trait MulAddE {
+pub(crate) trait MulAddE {
     fn mul_adde(self, y: Self, z: Self) -> Self;
 }
 

--- a/src/codegen/math/float/powf.rs
+++ b/src/codegen/math/float/powf.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Powf {
+pub(crate) trait Powf {
     fn powf(self, x: Self) -> Self;
 }
 

--- a/src/codegen/math/float/sin.rs
+++ b/src/codegen/math/float/sin.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Sin {
+pub(crate) trait Sin {
     fn sin(self) -> Self;
 }
 

--- a/src/codegen/math/float/sin_cos_pi.rs
+++ b/src/codegen/math/float/sin_cos_pi.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait SinCosPi: Sized {
+pub(crate) trait SinCosPi: Sized {
     type Output;
     fn sin_cos_pi(self) -> Self::Output;
 }

--- a/src/codegen/math/float/sin_pi.rs
+++ b/src/codegen/math/float/sin_pi.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait SinPi {
+pub(crate) trait SinPi {
     fn sin_pi(self) -> Self;
 }
 

--- a/src/codegen/math/float/sqrt.rs
+++ b/src/codegen/math/float/sqrt.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Sqrt {
+pub(crate) trait Sqrt {
     fn sqrt(self) -> Self;
 }
 

--- a/src/codegen/math/float/sqrte.rs
+++ b/src/codegen/math/float/sqrte.rs
@@ -6,7 +6,7 @@
 use crate::llvm::simd_fsqrt;
 use crate::*;
 
-crate trait Sqrte {
+pub(crate) trait Sqrte {
     fn sqrte(self) -> Self;
 }
 

--- a/src/codegen/math/float/tanh.rs
+++ b/src/codegen/math/float/tanh.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait Tanh {
+pub(crate) trait Tanh {
     fn tanh(self) -> Self;
 }
 

--- a/src/codegen/pointer_sized_int.rs
+++ b/src/codegen/pointer_sized_int.rs
@@ -4,24 +4,24 @@ use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(target_pointer_width = "8")] {
-        crate type isize_ = i8;
-        crate type usize_ = u8;
+        pub(crate) type isize_ = i8;
+        pub(crate) type usize_ = u8;
     } else if #[cfg(target_pointer_width = "16")] {
-        crate type isize_ = i16;
-        crate type usize_ = u16;
+        pub(crate) type isize_ = i16;
+        pub(crate) type usize_ = u16;
     } else if #[cfg(target_pointer_width = "32")] {
-        crate type isize_ = i32;
-        crate type usize_ = u32;
+        pub(crate) type isize_ = i32;
+        pub(crate) type usize_ = u32;
 
     } else if #[cfg(target_pointer_width = "64")] {
-        crate type isize_ = i64;
-        crate type usize_ = u64;
+        pub(crate) type isize_ = i64;
+        pub(crate) type usize_ = u64;
     } else if #[cfg(target_pointer_width = "64")] {
-        crate type isize_ = i64;
-        crate type usize_ = u64;
+        pub(crate) type isize_ = i64;
+        pub(crate) type usize_ = u64;
     } else if #[cfg(target_pointer_width = "128")] {
-        crate type isize_ = i128;
-        crate type usize_ = u128;
+        pub(crate) type isize_ = i128;
+        pub(crate) type usize_ = u128;
     } else {
         compile_error!("unsupported target_pointer_width");
     }

--- a/src/codegen/reductions.rs
+++ b/src/codegen/reductions.rs
@@ -1,1 +1,1 @@
-crate mod mask;
+pub(crate) mod mask;

--- a/src/codegen/reductions/mask.rs
+++ b/src/codegen/reductions/mask.rs
@@ -7,11 +7,11 @@
 
 use crate::*;
 
-crate trait All: crate::marker::Sized {
+pub(crate) trait All: crate::marker::Sized {
     unsafe fn all(self) -> bool;
 }
 
-crate trait Any: crate::marker::Sized {
+pub(crate) trait Any: crate::marker::Sized {
     unsafe fn any(self) -> bool;
 }
 

--- a/src/codegen/swap_bytes.rs
+++ b/src/codegen/swap_bytes.rs
@@ -5,7 +5,7 @@
 
 use crate::*;
 
-crate trait SwapBytes {
+pub(crate) trait SwapBytes {
     fn swap_bytes(self) -> Self;
 }
 

--- a/src/codegen/swap_bytes.rs
+++ b/src/codegen/swap_bytes.rs
@@ -15,7 +15,7 @@ macro_rules! impl_swap_bytes {
             impl SwapBytes for $id {
                 #[inline]
                 fn swap_bytes(self) -> Self {
-                    unsafe { shuffle!(self, [1, 0]) }
+                    shuffle!(self, [1, 0])
                 }
             }
         )+

--- a/src/codegen/vPtr.rs
+++ b/src/codegen/vPtr.rs
@@ -5,7 +5,7 @@ macro_rules! impl_simd_ptr {
      | $($tys:ty),*) => {
         #[derive(Copy, Clone)]
         #[repr(simd)]
-        pub struct $tuple_id<$ty>($(crate $tys),*);
+        pub struct $tuple_id<$ty>($(pub(crate) $tys),*);
         //^^^^^^^ leaked through SimdArray
 
         impl<$ty> crate::sealed::Seal for [$ptr_ty; $elem_count] {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,6 @@
     link_llvm_intrinsics,
     core_intrinsics,
     stmt_expr_attributes,
-    crate_visibility_modifier,
     custom_inner_attributes,
 )]
 #![allow(non_camel_case_types, non_snake_case,
@@ -344,6 +343,6 @@ pub use self::codegen::llvm::{
     __shuffle_vector8,
 };
 
-crate mod llvm {
-    crate use crate::codegen::llvm::*;
+pub(crate) mod llvm {
+    pub(crate) use crate::codegen::llvm::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,6 @@
     rustc_attrs,
     platform_intrinsics,
     stdsimd,
-    aarch64_target_feature,
     arm_target_feature,
     link_llvm_intrinsics,
     core_intrinsics,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -5,4 +5,4 @@ mod macros;
 
 #[cfg(test)]
 #[macro_use]
-crate mod utils;
+pub(crate) mod utils;


### PR DESCRIPTION
This crate is basically deprecated, but this is a fix that can be done with regex, so might as well make it.

Fixes #343