### PR TITLE
Fix docs

### DIFF
--- a/src/api/ops/vector_rotates.rs
+++ b/src/api/ops/vector_rotates.rs
@@ -23,8 +23,8 @@ macro_rules! impl_ops_vector_rotates {
             /// amount in the corresponding lane of `n`, wrapping the
             /// truncated bits to the beginning of the resulting integer.
             ///
-            /// Note: this is neither the same operation as `<<` nor equivalent
-            /// to `slice::rotate_left`.
+            /// Note: this is neither the same operation as `>>` nor equivalent
+            /// to `slice::rotate_right`.
             #[inline]
             pub fn rotate_right(self, n: $id) -> $id {
                 const LANE_WIDTH: $elem_ty =


### PR DESCRIPTION
In the docs for `rotate_right()`, this is mistakenly written:
```
Note: this is neither the same operation as << nor equivalent to slice::rotate_left.
```
when it should say
```
Note: this is neither the same operation as >> nor equivalent to slice::rotate_right.
```
This PR fixes the issue.