### PR TITLE
Stop using old-style `simd_shuffle`

### DIFF
--- a/.github/workflows/run-ci-script.yml
+++ b/.github/workflows/run-ci-script.yml
@@ -48,11 +48,10 @@ jobs:
             ~/.rustup/toolchains
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/rust-toolchain') }}
       - name: Install Toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
           # FIXME: change to nightly once https://github.com/rust-lang/packed_simd/pull/350 is merged
           # needs to be kept in sync with the toolchain files
-          toolchain: nightly-2023-06-14
           targets: ${{ inputs.target }}
           components: rustfmt
       - name: Generate Lockfile

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2023-06-14
+nightly

--- a/src/codegen/llvm.rs
+++ b/src/codegen/llvm.rs
@@ -5,14 +5,8 @@ use crate::sealed::Shuffle;
 #[allow(unused_imports)] // FIXME: spurious warning?
 use crate::sealed::Simd;
 
-// Shuffle intrinsics: expanded in users' crates, therefore public.
 extern "platform-intrinsic" {
-    pub fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
-    pub fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
-    pub fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U;
-    pub fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U;
-    pub fn simd_shuffle32<T, U>(x: T, y: T, idx: [u32; 32]) -> U;
-    pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U;
+    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -22,7 +16,7 @@ where
     T: Simd,
     <T as Simd>::Element: Shuffle<[u32; 2], Output = U>,
 {
-    simd_shuffle2(x, y, IDX)
+    simd_shuffle(x, y, IDX)
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -32,7 +26,7 @@ where
     T: Simd,
     <T as Simd>::Element: Shuffle<[u32; 4], Output = U>,
 {
-    simd_shuffle4(x, y, IDX)
+    simd_shuffle(x, y, IDX)
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -42,7 +36,7 @@ where
     T: Simd,
     <T as Simd>::Element: Shuffle<[u32; 8], Output = U>,
 {
-    simd_shuffle8(x, y, IDX)
+    simd_shuffle(x, y, IDX)
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -52,7 +46,7 @@ where
     T: Simd,
     <T as Simd>::Element: Shuffle<[u32; 16], Output = U>,
 {
-    simd_shuffle16(x, y, IDX)
+    simd_shuffle(x, y, IDX)
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -62,7 +56,7 @@ where
     T: Simd,
     <T as Simd>::Element: Shuffle<[u32; 32], Output = U>,
 {
-    simd_shuffle32(x, y, IDX)
+    simd_shuffle(x, y, IDX)
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -72,7 +66,7 @@ where
     T: Simd,
     <T as Simd>::Element: Shuffle<[u32; 64], Output = U>,
 {
-    simd_shuffle64(x, y, IDX)
+    simd_shuffle(x, y, IDX)
 }
 
 extern "platform-intrinsic" {


### PR DESCRIPTION
Found while fixing https://github.com/rust-lang/rust/issues/113500 (this PR is not necessary, but will allow us to make the compiler simpler)